### PR TITLE
Локальное копирование проекта

### DIFF
--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -15,5 +15,25 @@ module.exports = {
       "index.html",
     ],
     dest: path.join(__dirname, "..", "<%= dist %>")
+  },
+
+  /**
+   * Копирование расширения куда надо
+   * @see https://github.com/Adobe-CEP/CEP-Resources/wiki/CEP-6-HTML-Extension-Cookbook-for-CC-2015#where-are-the-extensions
+   *
+   * Аналог exec:sync для Windows
+   */
+  deploy: {
+    expand: true,
+    cwd: path.join(__dirname, "..", "<%= dist %>"),
+    src: [
+      ".debug",
+      "css/**",
+      "CSXS/**",
+      "js/**",
+      "jsx/**",
+      "index.html",
+    ],
+    dest: path.join(process.env.APPDATA || "/tmp/", "Adobe/CEP/extensions", "<%= pkg.name %>")
   }
 };

--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -1,5 +1,15 @@
 "use strict";
 
+/**
+ * Добавить к заданию удаленной синхронизации локальное
+ * копирование, если разработка идёт на Windows
+ */
+let syncTask = ["exec:sync"];
+
+if (process.platform === "win32") {
+  syncTask.push("copy:deploy");
+}
+
 module.exports = {
   less: {
     files: ["less/main.less", "src/**/*.less"],
@@ -15,6 +25,6 @@ module.exports = {
   },
   sync: {
     files: ["<%= dist %>/**/*.*"],
-    tasks: ["exec:sync"],
+    tasks: syncTask,
   },
 };


### PR DESCRIPTION
Если платформа -- Widows, то `grunt copy` скопирует всё [куда-надо](https://github.com/Adobe-CEP/CEP-Resources/wiki/CEP-6-HTML-Extension-Cookbook-for-CC-2015#where-are-the-extensions).
`grunt watch` будет поступать аналогично при изменении кода.
