### PR TITLE
Atom compromise

### DIFF
--- a/src/host/tsconfig.json
+++ b/src/host/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "atom": {
+    "rewriteTsconfig": true,
+    "formatOnSave": false
+  },
   "compilerOptions": {
     "module": "commonjs",
     "target": "es3",
@@ -7,11 +11,25 @@
     "sourceMap": false,
     "outDir": "build"
   },
+  "filesGlob": [
+    "../../typings/adobe/lib.core.d.ts",
+    "../../typings/adobe/extended-cs3.d.ts",
+    "../../typings/adobe/illustrator-cs3.d.ts",
+    "../interfaces.d.ts",
+    "./**/*.ts",
+    "!node_modules/**/*.*"
+  ],
   "files": [
     "../../typings/adobe/lib.core.d.ts",
     "../../typings/adobe/extended-cs3.d.ts",
     "../../typings/adobe/illustrator-cs3.d.ts",
     "../interfaces.d.ts",
-    "index.ts"
+    "./applySolution.ts",
+    "./constants.ts",
+    "./getContour.ts",
+    "./handlers.ts",
+    "./index.ts",
+    "./solution.ts",
+    "./utils.ts"
   ]
 }

--- a/src/panel/tsconfig.json
+++ b/src/panel/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "atom": {
+    "rewriteTsconfig": true,
+    "formatOnSave": false
+  },
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
@@ -6,12 +10,28 @@
     "sourceMap": false,
     "outDir": "build"
   },
+  "filesGlob": [
+    "../../typings/node/node.d.ts",
+    "../../typings/adobe/csInterface.d.ts",
+    "../../typings/angularjs/angular.d.ts",
+    "../*.d.ts",
+    "./**/*.ts",
+    "!node_modules/**/*.*"
+  ],
   "files": [
     "../../typings/node/node.d.ts",
     "../../typings/adobe/csInterface.d.ts",
     "../../typings/angularjs/angular.d.ts",
-    "../interfaces.d.ts",
     "../angulars.d.ts",
-    "index.ts"
+    "../interfaces.d.ts",
+    "./controllers/index.ts",
+    "./controllers/main.ts",
+    "./controllers/thememanager.ts",
+    "./index.ts",
+    "./services/3075_eticetka.ai.ts",
+    "./services/csInterface.ts",
+    "./services/ilst.ts",
+    "./services/index.ts",
+    "./services/solver.ts"
   ]
 }


### PR DESCRIPTION
Плагин `atom-typescript` безбожно ТОРМОЗИТ! Вплоть до ООМ киллера.
А без этого плагина Атом не интересен в контексте TypeScript;

Но решение всё-таки есть. Как минимум, для такой конфигурации:
- atom: 1.7.2,
- atom-typescript: 8.10.2,
- os: linux 4.4.0-22-generic x86_64,
- tsc: 1.8.10,

Компромис:
- дать Атому право колбасить `tsconfig.json` по своему усмотрению;
- рассчитывать только на `filesGlob` и держать порох сухим;
